### PR TITLE
opening a tutor page in a new browser frame, rather than an iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ The only available option is the `--lang` or `-l` that allows you to choose one 
 * `%%tutor --lang python2` or `%%tutor -l python2` to show a pythontutor IFrame with python2 code.
 * `%%tutor --lang java` or `%%tutor -l java` to show a pythontutor IFrame with java code.
 * `%%tutor --lang javascript` or `%%tutor -l javascript` to show a pythontutor IFrame with javascript code.
-
+* `%%tutor --tab` or `%%tutor -t` to tell webbrowser to open the url,
+  resulting in a new browser frame rather than an IFrame (should
+  combine with --lang)
+  
 ## Example (in spanish)
 
 [Example notebook](http://nbviewer.ipython.org/github/Pybonacci/notebooks/blob/master/tutormagic.ipynb).

--- a/tutormagic.py
+++ b/tutormagic.py
@@ -26,6 +26,7 @@ To enable the magics below, execute ``%load_ext tutormagic``.
 #   kikocorreoso
 #-----------------------------------------------------------------------------
 
+import webbrowser
 import warnings
 warnings.simplefilter("always")
 import sys
@@ -63,6 +64,11 @@ class TutorMagics(Magics):
     @argument(
         '-h', '--height', action='store', nargs=1,
         help="Change the height of the output area display"
+        )
+
+    @argument(
+        '-t', '--tab', action='store_true',
+        help="Open pythontutor in a new tab",
         )
 
     #@needs_local_scope
@@ -107,11 +113,15 @@ class TutorMagics(Magics):
         if lang == "javascript":
             url += "py=js&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
 
-        # Display the results in the output area
-        if args.height:
-            display(IFrame(url, height = int(args.height[0]), width = "100%"))
+        # Display in new tab, or in iframe?
+        if args.tab:
+            webbrowser.open(url)
         else:
-            display(IFrame(url, height = 350, width = "100%"))
+            # Display the results in the output area
+            if args.height:
+                display(IFrame(url, height = int(args.height[0]), width = "100%"))
+            else:
+                display(IFrame(url, height = 350, width = "100%"))
 
 __doc__ = __doc__.format(
     tutormagic_DOC = dedent(TutorMagics.tutor.__doc__))


### PR DESCRIPTION
This should give a new option -t or --tab. Instead of adding an IFRame, it uses Python's webbrowser module to tell the browser to open the url. In typical configuration, this leads to the url being opened in a new browser frame. 

Useful in particular for larger code examples. 