### PR TITLE
Allowing use of SSL for PythonTutor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ this option will be ignored.
 The ``--tab`` or ``-t`` option will open http://pythontutor.com in a new tab 
 instead of within an IFrame within the notebook.
 
+Use the ``--secure`` or ``-s`` option to open pythontutor.com using HTTPS. This is useful when being used in a notebook that uses SSL.
+
 Example (in spanish)
 --------------------
 

--- a/tutormagic.py
+++ b/tutormagic.py
@@ -73,6 +73,11 @@ class TutorMagics(Magics):
         help="Open pythontutor in a new tab",
         )
 
+    @argument(
+        '-s', '--secure', action='store_true',
+        help="Open pythontutor using https",
+        )
+
     #@needs_local_scope
     @argument(
         'code',
@@ -111,7 +116,13 @@ class TutorMagics(Magics):
         else:
             lang = "python3"
 
-        url = "http://pythontutor.com/iframe-embed.html#code="
+        # Sometimes user will want SSL pythontutor site if 
+        # jupyter/hub is using SSL as well
+        protocol = 'http://'
+        if args.secure:
+            protocol = 'https://'
+
+        url = protocol + "pythontutor.com/iframe-embed.html#code="
         url += quote(cell)
         url += "&origin=opt-frontend.js&cumulative=false&heapPrimitives=false"
         url += "&textReferences=false&"


### PR DESCRIPTION
When loading a notebook over SSL, browsers will not load http://pythontutor.com as an iFrame due to security issues. This now allows the user to use --secure or -s to switch on using HTTPS