### PR TITLE
Adding ability to only show a link to PythonTutor + Ability to customize some of the PythonTutor options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,7 @@ Use the ``--secure`` or ``-s`` option to open PythonTutor.com using HTTPS. This 
 Use the ``--link`` option to display a link to PythonTutor, not via an iFrame.
 
 You can customize how PythonTutor is rendered via the three options available in the URL params. The following options are available:
+
   - Use the ``--cumulative`` option to tell PythonTutor to the cumulative to True
   - Use the ``--heapPrimitives`` option to tell PythonTutor to render objects on the heap
   - Use the ``--textReferences`` option to tell PythonTutor to use text labels for references

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,14 @@ this option will be ignored.
 The ``--tab`` or ``-t`` option will open http://pythontutor.com in a new tab 
 instead of within an IFrame within the notebook.
 
-Use the ``--secure`` or ``-s`` option to open pythontutor.com using HTTPS. This is useful when being used in a notebook that uses SSL.
+Use the ``--secure`` or ``-s`` option to open PythonTutor.com using HTTPS. This is useful when being used in a notebook that uses SSL.
+
+Use the ``--link`` option to display a link to PythonTutor, not via an iFrame.
+
+You can customize how PythonTutor is rendered via the three options available in the URL params. The following options are available:
+  - Use the ``--cumulative`` option to tell PythonTutor to the cumulative to True
+  - Use the ``--heapPrimitives`` option to tell PythonTutor to render objects on the heap
+  - Use the ``--textReferences`` option to tell PythonTutor to use text labels for references
 
 Example (in spanish)
 --------------------

--- a/tutormagic.py
+++ b/tutormagic.py
@@ -106,6 +106,11 @@ class TutorMagics(Magics):
         help="PythonTutor config: Jump to last instruction?", 
         )
 
+    @argument(
+        '--curInstr', action='store', default=0,
+        help="PythonTutor config: Start at which step?", 
+        )
+
     #@needs_local_scope
     @argument(
         'code',
@@ -157,9 +162,10 @@ class TutorMagics(Magics):
         # Add custom pythontutor options, defaults to all false
         url += "&cumulative={}".format(str(args.cumulative).lower())
         url += "&heapPrimitives={}".format(str(args.heapPrimitives).lower())
-        url += "&textReferences={}&".format(str(args.textReferences).lower())
-        url += "&jumpToEnd={}&".format(str(args.jumpToEnd).lower())
-        
+        url += "&textReferences={}".format(str(args.textReferences).lower())
+        url += "&jumpToEnd={}".format(str(args.jumpToEnd).lower())
+        url += "&curInstr={}&".format(str(args.curInstr).lower())
+
         # Setup the language URL param
         if lang == "python3":
             url += "py=3"
@@ -179,7 +185,7 @@ class TutorMagics(Magics):
             url += "py=cpp"
         
         # Add the rest of the misc options to pythontutor
-        url += "&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"       
+        url += "&rawInputLstJSON=%5B%5D&codeDivWidth=50%25&codeDivHeight=100%25"       
 
         # Display in new tab, or in iframe, or link to it via anchor link?
         if args.link:

--- a/tutormagic.py
+++ b/tutormagic.py
@@ -53,7 +53,9 @@ class TutorMagics(Magics):
     """
     def __init__(self, shell):
         super(TutorMagics, self).__init__(shell)
-        self.custom_link_css = "box-sizing: border-box; padding: 0 5px; border: 1px solid #CFCFCF; font-size: 80%;"
+        self.custom_link_css = "box-sizing: border-box; \
+                                padding: 0 5px; \
+                                border: 1px solid #CFCFCF;"
 
     @skip_doctest
     @magic_arguments()
@@ -177,7 +179,11 @@ class TutorMagics(Magics):
         if args.link:
             # Create html link to pythontutor
             from IPython.display import HTML
-            display(HTML(data='<strong><a style="{}" target="_" href={}>Python Tutor</a></strong>'.format(self.custom_link_css, url)))
+            display(HTML(data='<div style="text-align: center;">\
+                                <strong>\
+                                    <a style="{}" target="_" href={}>Python Tutor</a>\
+                                </strong>\
+                                </div>'.format(self.custom_link_css, url)))
             
             # Run cell like normal
             self.shell.run_cell(cell)

--- a/tutormagic.py
+++ b/tutormagic.py
@@ -53,6 +53,7 @@ class TutorMagics(Magics):
     """
     def __init__(self, shell):
         super(TutorMagics, self).__init__(shell)
+        self.custom_link_css = "box-sizing: border-box; padding: 0 5px; border: 1px solid #CFCFCF; font-size: 80%;"
 
     @skip_doctest
     @magic_arguments()
@@ -76,6 +77,26 @@ class TutorMagics(Magics):
     @argument(
         '-s', '--secure', action='store_true',
         help="Open pythontutor using https",
+        )
+
+    @argument(
+        '--link', action='store_true',
+        help="Just display a link to pythontutor",
+        )
+
+    @argument(
+        '--cumulative', action='store_true', default=False,
+        help="PythonTutor config: Set the cumulative option to True", 
+        )
+    
+    @argument(
+        '--heapPrimitives', action='store_true', default=False,
+        help="PythonTutor config: Render objects on the heap", 
+        )
+    
+    @argument(
+        '--textReferences', action='store_true', default=False,
+        help="PythonTutor config: Use text labels for references", 
         )
 
     #@needs_local_scope
@@ -124,27 +145,44 @@ class TutorMagics(Magics):
 
         url = protocol + "pythontutor.com/iframe-embed.html#code="
         url += quote(cell)
-        url += "&origin=opt-frontend.js&cumulative=false&heapPrimitives=false"
-        url += "&textReferences=false&"
-        if lang == "python3":
-            url += "py=3&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
-        if lang == "python2":
-            url += "py=2&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
-        if lang == "java":
-            url += "py=java&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
-        if lang == "javascript":
-            url += "py=js&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
-        if lang == "typescript":
-            url += "py=ts&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
-        if lang == "ruby":
-            url += "py=ruby&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
-        if lang == "c":
-            url += "py=c&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
-        if lang == "c++":
-            url += "py=cpp&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"
+        url += "&origin=opt-frontend.js"
 
-        # Display in new tab, or in iframe?
-        if args.tab:
+        # Add custom pythontutor options, defaults to all false
+        url += "&cumulative={}".format(str(args.cumulative).lower())
+        url += "&heapPrimitives={}".format(str(args.heapPrimitives).lower())
+        url += "&textReferences={}&".format(str(args.textReferences).lower())
+        
+        # Setup the language URL param
+        if lang == "python3":
+            url += "py=3"
+        elif lang == "python2":
+            url += "py=2"
+        elif lang == "java":
+            url += "py=java"
+        elif lang == "javascript":
+            url += "py=js"
+        elif lang == "typescript":
+            url += "py=ts"
+        elif lang == "ruby":
+            url += "py=ruby"
+        elif lang == "c":
+            url += "py=c"
+        elif lang == "c++":
+            url += "py=cpp"
+        
+        # Add the rest of the misc options to pythontutor
+        url += "&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=50%25&codeDivHeight=100%25"       
+
+        # Display in new tab, or in iframe, or link to it via anchor link?
+        if args.link:
+            # Create html link to pythontutor
+            from IPython.display import HTML
+            display(HTML(data='<strong><a style="{}" target="_" href={}>Python Tutor</a></strong>'.format(self.custom_link_css, url)))
+            
+            # Run cell like normal
+            self.shell.run_cell(cell)
+        elif args.tab:
+            # Open up a new tab in the browser to pythontutor URL
             webbrowser.open_new_tab(url)
         else:
             # Display the results in the output area

--- a/tutormagic.py
+++ b/tutormagic.py
@@ -101,6 +101,11 @@ class TutorMagics(Magics):
         help="PythonTutor config: Use text labels for references", 
         )
 
+    @argument(
+        '--jumpToEnd', action='store_true', default=False,
+        help="PythonTutor config: Jump to last instruction?", 
+        )
+
     #@needs_local_scope
     @argument(
         'code',
@@ -153,6 +158,7 @@ class TutorMagics(Magics):
         url += "&cumulative={}".format(str(args.cumulative).lower())
         url += "&heapPrimitives={}".format(str(args.heapPrimitives).lower())
         url += "&textReferences={}&".format(str(args.textReferences).lower())
+        url += "&jumpToEnd={}&".format(str(args.jumpToEnd).lower())
         
         # Setup the language URL param
         if lang == "python3":


### PR DESCRIPTION
I have an idea for showing a link to PythonTutor, and not display it as an iFrame. I added the --link option to the magic for this purpose. I do not like the custom CSS much but will do for my needs. 

I added some other options as well to customize the PythonTutor interface via the URL params.

Updated the README to reflect these new options. Let me know if you find this useful, or if you think I should change anything.